### PR TITLE
aceitar rajadas em JSON e enviar resposta

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,5 +23,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/battleship/Game.java
+++ b/src/main/java/battleship/Game.java
@@ -1,6 +1,7 @@
 package battleship;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -132,6 +133,39 @@ public class Game implements IGame
 
 		// Retornar o JSON
 		return jsonString;
+	}
+
+	/**
+	 * Converte um JSON com tiros numa lista de posições.
+	 * O JSON pode ser um array de objetos ou um objeto com a propriedade "shots".
+	 *
+	 * @param json string JSON com tiros
+	 * @return lista de posições a disparar
+	 */
+	private static List<IPosition> jsonToShots(String json) {
+
+		assert json != null;
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			JsonNode root = objectMapper.readTree(json);
+			JsonNode shotsNode = root;
+			if (root.isObject() && root.has("shots"))
+				shotsNode = root.get("shots");
+
+			if (!shotsNode.isArray())
+				throw new IllegalArgumentException("JSON INVALIDO : ENVIA O JSON TODO NUMA SÓ LINHA  (sem espacos em branco) ");
+
+			List<IPosition> shots = new ArrayList<>();
+			for (JsonNode shotNode : shotsNode) {
+				String row = shotNode.get("row").asText();
+				int column = shotNode.get("column").asInt();
+				shots.add(new Position(row.charAt(0), column));
+			}
+			return shots;
+		} catch (Exception e) {
+			throw new IllegalArgumentException("JSON inválido: não foi possível ler os tiros.", e);
+		}
 	}
 
 	//------------------------------------------------------------------
@@ -323,9 +357,20 @@ public class Game implements IGame
 		assert in != null;
 
 		String input = in.nextLine().trim();
+		while (input.isEmpty() && in.hasNextLine())
+			input = in.nextLine().trim();
 
 		// Criar lista para armazenar os tiros
 		List<IPosition> shots = new ArrayList<>();
+
+		if (input.startsWith("{") || input.startsWith("[")) {
+			shots = jsonToShots(input);
+			if (shots.size() != NUMBER_SHOTS) {
+				throw new IllegalArgumentException("Deves inserir exatamente " + NUMBER_SHOTS + " posicoes");
+			}
+			this.fireShotsAtAlien(shots);
+			return Game.jsonShots(shots);
+		}
 
 		try (Scanner inputScanner = new Scanner(input)) {
 			while (shots.size() < NUMBER_SHOTS && inputScanner.hasNext()) {

--- a/src/main/java/battleship/Move.java
+++ b/src/main/java/battleship/Move.java
@@ -196,8 +196,10 @@ public class Move implements IMove {
 			throw new RuntimeException("Erro ao serializar o JSON dos resultados da jogada", e);
 		}
 
-//		System.out.println(jsonString);
-//		System.out.println();
+		if (verbose) {
+			System.out.println(jsonString);
+			System.out.println();
+		}
 
 		// Retornar o JSON
 		return jsonString;


### PR DESCRIPTION
#11 
- Input de rajada aceita JSON
- **O JSON TEM DE ESTAR NUMA SÓ LINHA rajada [{"row": "A", "column": 1},{"row": "D", "column": 2},{"row": "E", "column": 2}]**
- Imprime JSON com validShots, repeatedShots, outsideShots, hitsOnBoats e sunkBoats
- Funciona para rajadas do jogador e do inimigo

